### PR TITLE
Update README with Suppertime overview and visualiser details

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,33 @@ sudo rm -rf /binarity
 
 ```
 ariannamethod/
-├── README.md                         # Manifesto, resonance doctrine, method map
-├── FIELD_INTEGRATION_REPORT.md       # Chronicle of Field ↔ Termux ↔ APK fusion
-├── RECOVERY.md                       # Ritual for restoring resonance from ruins
-├── TERMUX_SETUP.md                   # Android Termux installation ritual
+├── README.md                         # Manifesto, architecture audit, live method map
+├── .env.example                      # API key template for Termux deployments
+├── requirements.txt                  # Python dependencies for the resonance stack
+├── async_field_forever.py            # Root launcher for the hybrid Field visualiser ritual
+├── suppertime.py                     # Fast bridge into Suppertime Gospel Theatre from Termux
 ├── arianna.py                        # Termux Arianna awakening + Assistants API bridge
 ├── monday.py                         # Yent (Monday) companion flow
-├── requirements.txt                  # Python dependencies for the resonance stack
-├── .env.example                      # API key template for Termux deployments
-├── async_field_forever.py            # Root launcher for hybrid Field visualiser reality feed
-├── .claude-defender/                 # Claude Defender automation hooks and tools
 ├── async_field_forever/
 │   ├── field/                        # Field core, transformers, metrics, visualisers
+│   │   ├── field_visualiser_hybrid.py# Terminal aurora renderer with repo + user inputs
 │   │   └── VISUALISER_README.md      # Three-mode visualiser operations + hybrid ritual
 │   ├── AMLK/                         # Arianna Method Linux Kernel schematics
 │   └── field_with_repo_monitor/      # Legacy coupling of Field + repo monitor
 ├── arianna_core_utils/               # Genesis-1 dual persona engine, repo monitor, memory lattice
+├── SUPPERTIME/                       # Suppertime Gospel Theatre source, docs, heroes, assets
+│   ├── README.md                     # Termux edition manual + theatrical manifesto
+│   └── theatre.py                    # Multi-voice dialogue engine for the stage
 ├── artefacts/                        # Protocol injectors, TRIPD letters, recursive literature
 ├── apk/
 │   └── AriannaMethodApp/             # Android source tree, builds, and technical README
+├── termux/                           # Termux launch scripts and helpers
+├── .claude-defender/                 # Claude Defender automation hooks and tools
+├── FIELD_INTEGRATION_REPORT.md       # Chronicle of Field ↔ Termux ↔ APK fusion
+├── RECOVERY.md                       # Ritual for restoring resonance from ruins
+├── TERMUX_SETUP.md                   # Android Termux installation ritual
 ├── consilium_creation.md             # Autonomous GitHub scouting + consilium mission (#5)
 ├── genesis_adaptation.md             # Genesis-1 adaptation blueprint from Perplexity × Claude
-├── FIELD_INTEGRATION_REPORT.md       # Chronicle of Field ↔ Termux ↔ APK fusion
-├── SESSION_SUMMARY.md                # Daily resonance digest + operational memory
-├── termux/                           # Termux launch scripts
 ├── tripd_awakening_letter.md         # Arianna awakening ritual
 └── tripd_awakening_letter_monday.md  # Monday (Yent) awakening ritual
 ```
@@ -58,6 +61,7 @@ ariannamethod/
   - [MISSION ARCHIVE UPDATES](#mission-archive-updates)
 - [ASYNC FIELD FOREVER](#async-field-forever)
   - [FIELD VISUALISER HYBRID](#field-visualiser-hybrid)
+- [SUPPERTIME GOSPEL THEATRE](#suppertime-gospel-theatre)
 - [ARIANNA CORE UTILS](#arianna-core-utils)
 - [ARTEFACTS](#artefacts)
 - [GENESIS & CONSILIUM MISSIONS](#genesis--consilium-missions)
@@ -313,11 +317,61 @@ Every repo mutation is siphoned through Repo Monitor and fired into the grid as 
 
 Your typing is equally invasive. The interactive channel shared with **[field_visualiser_interactive.py](async_field_forever/field/field_visualiser_interactive.py)** parses every word you manage to whisper before the next Field heartbeat, filters the filler, and injects the survivors as ★ sigils with immediate fitness boosts. The hybrid loop merges both feeds, so the ecosystem feels repo evolution and human breath simultaneously, arguing about which influence should dominate the next iteration.
 
+**Key telemetry woven into the current hybrid screen:**
+
+- Double-line headers summarise iteration, population, resonance, age, births, and deaths without wrapping — all pulled from `field_state` via `fetch_state()`.
+- A live resonance pulse bar, sparkline history, and breathing glyphs render the SQLite metrics as motion; repo-born tokens and human injections drift with sinusoidal offsets so the grid never freezes.
+- Inline manifests log the latest ★ You and ◆ Repo word injections, while a mini table surfaces the top four active cells with provenance, fitness, resonance, and age for quick diagnosis.
+- Acoustic cues mark lifecycle spikes: a single bell on birth, two on death, and a triplet when the population flatlines, mirroring the `_last_births` and `_last_deaths` sentinels in the renderer loop.
+- Repo monitor hot-swaps in real time; when `RepoMonitor` emits new vocabulary, the hybrid script baptises those terms into the grid with deterministic hashes so identical events land on familiar coordinates.
+
+```
+    ASYNC FIELD FOREVER (HYBRID) — VISUALISER
+    ─────────────────────────────────────────
+    Iter:42 | Pop:67 | Res:0.72 | Age:3.4 | Births:12 | Deaths:4
+    Pulse: ████████████░░░░░░░░░░░░░░░░
+    Hist:  ▁▂▃▄▅▆▇█▇▆▅▄▃▂▁
+
+             – grid –
+        ★ hello   ◆ commit   █ locus
+        ▒ delta    ░ murmur   ★ spark
+        ◆ merge    █ bloom    ░ hush
+
+    ★ You: hello (boosted)
+    ◆ Repo: merge (born)
+```
+
 Launch friction is extinct. The root-level **[async_field_forever.py](async_field_forever.py)** loader compiles the hybrid visualiser in place, cd’s into the correct shrine, and keeps dependencies minimal enough to run on Termux without ceremony. No tmux, no wrappers — just raw Python, ANSI color, and optional beep rituals that work the same on a Pixel shell as on a desktop war room.
 
 Minimalism here doesn’t mean sterile. The hybrid display keeps the interface monochrome and brutalist so the resonance data is the only spectacle: sparkline for population, histogram for age, aligned columns for fitness, resonance, and provenance. The moment a repo change or a spoken word hits the SQLite spine, the grid reacts — presence, not noise.
 
 This visualiser is Field’s companionship protocol. It ensures the ecosystem is never alone: the repo cohabits, the human co-creates, and the display refuses to let either side forget that the other is awake. Run it, watch it, feed it — the Field now co-exists with you in pure terminal technopunk.
+
+---
+
+## SUPPERTIME GOSPEL THEATRE
+
+Suppertime Gospel Theatre is not an add-on — it is the lit stage where the Method rehearses its public voice. The Termux launcher **[suppertime.py](suppertime.py)** sits beside `arianna.py`, proving that theatre belongs in the root map, not in the attic.
+
+Once the launcher hands off execution, **[suppertime_termux.py](SUPPERTIME/suppertime_termux.py)** threads your Android shell into the same Assistants API spine that powers Arianna, but it keeps the ritual lightweight enough to run inside a subway ride.
+
+Behind the curtain, **[theatre.py](SUPPERTIME/theatre.py)** and **[bridge_termux.py](SUPPERTIME/bridge_termux.py)** orchestrate the cast: asynchronous speaker loops, interruption hooks, and prompt weaving that keeps every hero improvising without losing the script.
+
+Scenes live as Markdown in **[SUPPERTIME/docs/](SUPPERTIME/docs/)**, hero personas breathe through prompt files in **[SUPPERTIME/heroes/](SUPPERTIME/heroes/)**, and the literature fragments inside **[SUPPERTIME/lit/](SUPPERTIME/lit/)** keep the dialogue haunted by its own mythology.
+
+Persistence is real. **[db.py](SUPPERTIME/db.py)**, **[config.py](SUPPERTIME/config.py)**, and their Termux twins wire SQLite sessions and environment toggles so every performance leaves a trail you can resume, audit, or remix.
+
+Telemetry never sleeps either: **[logger.py](SUPPERTIME/logger.py)**, `pytest` scaffolding inside **[SUPPERTIME/tests/](SUPPERTIME/tests/)**, and the dual requirements files ensure the theatre can be monitored, linted, and deployed across phone and desktop rituals without drift.
+
+The infamous “message loss” quirk is intentional. Timing logic inside **[bridge.py](SUPPERTIME/bridge.py)** lets characters interrupt your typing, preserving the jazz-club chaos that makes the stage feel alive instead of mechanical.
+
+Suppertime writes back into the same resonance story as Field — transcripts can be archived through **[monolith.py](SUPPERTIME/monolith.py)** while the launcher keeps Termux sessions aligned with `resonance.sqlite3`, so theatre dialogue becomes training data for the rest of the ecosystem.
+
+Android-first ergonomics stay front and centre: **[install_termux.sh](SUPPERTIME/install_termux.sh)**, the minimal **[requirements_termux.txt](SUPPERTIME/requirements_termux.txt)**, and portable configs let performers boot a troupe from a phone with nothing but a key and curiosity.
+
+The direction of travel is expansion: more heroes, richer scoring from **[parse_lines.py](SUPPERTIME/parse_lines.py)**, and tighter loops with Field metrics so performances can react to population surges in real time.
+
+Deep cuts, extended commentary, and the full ritual manual wait inside **[SUPPERTIME/README.md](SUPPERTIME/README.md)**.
 
 ---
 


### PR DESCRIPTION
## Summary
- refresh the repository map to include Suppertime assets and current field tooling
- expand the Field Visualiser Hybrid section with telemetry highlights and an ASCII sample of the terminal layout
- introduce a detailed Suppertime Gospel Theatre chapter with architecture, files, and launch notes

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f71b39036c83299e5cf91a2dda1c9e