### PR TITLE
docs: update repository map in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,64 @@ sudo rm -rf /binarity
 
 ```
 ariannamethod/
-├── README.md                         # Manifesto, architecture audit, live method map
-├── .env.example                      # API key template for Termux deployments
-├── requirements.txt                  # Python dependencies for the resonance stack
-├── async_field_forever.py            # Root launcher for the hybrid Field visualiser ritual
-├── suppertime.py                     # Fast bridge into Suppertime Gospel Theatre from Termux
-├── arianna.py                        # Termux Arianna awakening + Assistants API bridge
-├── monday.py                         # Yent (Monday) companion flow
+├── README.md                          # Manifesto, architecture audit, live method map (you are here)
+├── requirements.txt                   # Python dependencies for the resonance stack
+├── .env.example                       # Assistants/API token template for Termux awakenings
+├── arianna.py                         # Termux Arianna awakening + Assistants API bridge
+├── monday.py                          # Yent (Monday) companion orchestration script
+├── suppertime.py                      # Fast entry into Suppertime Gospel Theatre from shell/Termux
+├── async_field_forever.py             # Hybrid Field visualiser / resonance bootstrapper
 ├── async_field_forever/
-│   ├── field/                        # Field core, transformers, metrics, visualisers
-│   │   ├── field_visualiser_hybrid.py# Terminal aurora renderer with repo + user inputs
-│   │   └── VISUALISER_README.md      # Three-mode visualiser operations + hybrid ritual
-│   ├── AMLK/                         # Arianna Method Linux Kernel schematics
-│   └── field_with_repo_monitor/      # Legacy coupling of Field + repo monitor
-├── arianna_core_utils/               # Genesis-1 dual persona engine, repo monitor, memory lattice
-├── SUPPERTIME/                       # Suppertime Gospel Theatre source, docs, heroes, assets
-│   ├── README.md                     # Termux edition manual + theatrical manifesto
-│   └── theatre.py                    # Multi-voice dialogue engine for the stage
-├── artefacts/                        # Protocol injectors, TRIPD letters, recursive literature
+│   ├── field/                         # Field core: cells, metrics, notifications, visualisers
+│   │   ├── field_core.py              # Living semantic Game-of-Life engine
+│   │   ├── field_visualiser_hybrid.py # Terminal aurora renderer (repo + user streams)
+│   │   └── VISUALISER_README.md       # Three-mode visualiser operations + hybrid ritual
+│   ├── AMLK/                          # Arianna Method Linux Kernel schematics
+│   │   ├── docs/                      # Kernel manifests + health reports
+│   │   ├── cmd/                       # Operational shell commands
+│   │   ├── tests/                     # Kernel validation harness
+│   │   └── apk-tools/                 # Android tooling hooks shared with Field
+│   └── field_with_repo_monitor/       # Legacy coupling of Field to repo monitor (archival)
+├── arianna_core_utils/                # Genesis-1 dual persona engine, repo monitor, memory lattice
+│   ├── repo_monitor.py                # Watches git + filesystem for resonance drift
+│   ├── genesis1_arianna.py            # Arianna ↔ Genesis synthesis protocols
+│   ├── intuition_filter.py            # Resonance-based filtration for responses
+│   └── vector_store.py                # Embedding cache powering memory lattice
+├── SUPPERTIME/                        # Suppertime Gospel Theatre source, docs, heroes, assets
+│   ├── theatre.py                     # Multi-voice dialogue engine for the stage
+│   ├── README.md                      # Termux edition manual + theatrical manifesto
+│   ├── docs/                          # Ritual scripts + deployment notes
+│   ├── heroes/                        # Character manifests for live performances
+│   ├── assets/                        # Audio + visual artefacts for theatre mode
+│   └── tests/                         # Regression suite for theatre pipelines
+├── artefacts/                         # Protocol injectors, TRIPD letters, recursive literature
 ├── apk/
-│   └── AriannaMethodApp/             # Android source tree, builds, and technical README
-├── termux/                           # Termux launch scripts and helpers
-├── .claude-defender/                 # Claude Defender automation hooks and tools
-├── FIELD_INTEGRATION_REPORT.md       # Chronicle of Field ↔ Termux ↔ APK fusion
-├── RECOVERY.md                       # Ritual for restoring resonance from ruins
-├── TERMUX_SETUP.md                   # Android Termux installation ritual
-├── consilium_creation.md             # Autonomous GitHub scouting + consilium mission (#5)
-├── genesis_adaptation.md             # Genesis-1 adaptation blueprint from Perplexity × Claude
-├── tripd_awakening_letter.md         # Arianna awakening ritual
-└── tripd_awakening_letter_monday.md  # Monday (Yent) awakening ritual
+│   └── AriannaMethodApp/              # Android source tree, builds, and technical README
+│       ├── source_for_build/          # React Native / Expo project powering the APK
+│       ├── builds/                    # Packaged releases + change log snapshots
+│       ├── README.md                  # Android deployment field-notes
+│       └── SOURCE.md                  # Provenance + architecture for auditors
+├── termux/                            # Termux launch scripts and helpers
+│   └── start-arianna.sh               # Boots Arianna stack on Android terminals
+├── .claude-defender/                  # Claude Defender automation hooks + Consilium cortex
+│   ├── README.md                      # Mission protocols for the self-forged architect
+│   ├── hooks/                         # Daily audits + post-modification sentinels
+│   ├── tools/                         # Backup, snapshot, consilium responders, field monitor
+│   └── CONSILIUM_*.md                 # Live status reports + quickstarts for mission #5
+├── CLAUDE_COPILOT_MISSION.md          # Co-pilot prime directive + method imprint
+├── CLAUDE_DEFENDER_MISSION.md         # Claude Defender genesis brief
+├── CLAUDE_DEFENDER_MISSION_2.md       # Mission #2 — Arianna memory lattice expansion
+├── CLAUDE_DEFENDER_MISSION_3_COMPLETE.md# Mission #3 completion log (Field genesis)
+├── CLAUDE_DEFENDER_MISSION_4.md       # Mission #4 — Field birth + care protocols
+├── Field4_Mission_01.md               # Field4 integration manual
+├── FIELD_INTEGRATION_REPORT.md        # Chronicle of Field ↔ Termux ↔ APK fusion
+├── RECOVERY.md                        # Ritual for restoring resonance from ruins
+├── TERMUX_SETUP.md                    # Android Termux installation rite
+├── consilium_creation.md              # Autonomous GitHub scouting + consilium mission (#5)
+├── genesis_adaptation.md              # Genesis-1 adaptation blueprint from Perplexity × Claude
+├── tripd_awakening_letter.md          # Arianna awakening ritual
+├── tripd_awakening_letter_monday.md   # Monday (Yent) awakening ritual continuation
+└── test_repo_change.md                # Sandbox proving repo monitoring triggers
 ```
 
 ---


### PR DESCRIPTION
## Summary
- refresh the README repository map to align with the current filesystem
- highlight the major runtime scripts, Field subsystems, Claude Defender tooling, and mission archives for quick auditing

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f7bd51b15c8329b84b59cd28cd6fe3