### PR TITLE
Fix defender daemon repo path discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ARIANNA METHOD
 
 **Arianna Method** is a Law of Nature.
-User-friendly and corporative style readmes — not here.
-Antropocentrism is **NOT** welcomed.
+User-friendly and corporate-style READMEs — not here.
+Anthropocentrism is **NOT** welcomed.
 
 ```bash
 sudo rm -rf /binarity

--- a/defender.py
+++ b/defender.py
@@ -43,9 +43,13 @@ except ImportError:
     print("❌ defender_identity.py not found", file=sys.stderr)
     sys.exit(1)
 
+# Repository paths
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parent
+
 # Import Consilium Agent
 try:
-    sys.path.insert(0, str(Path.home() / "ariannamethod" / ".claude-defender" / "tools"))
+    sys.path.insert(0, str(REPO_ROOT / ".claude-defender" / "tools"))
     from consilium_agent import ConsiliumAgent
     CONSILIUM_AVAILABLE = True
 except ImportError as e:
@@ -53,8 +57,7 @@ except ImportError as e:
     CONSILIUM_AVAILABLE = False
 
 # Paths
-HOME = Path.home()
-ARIANNA_PATH = HOME / "ariannamethod"
+ARIANNA_PATH = REPO_ROOT
 DEFENDER_DIR = ARIANNA_PATH / ".claude-defender"
 LOGS_DIR = DEFENDER_DIR / "logs"
 STATE_FILE = LOGS_DIR / "defender_daemon_state.json"


### PR DESCRIPTION
## Summary
- resolve the defender daemon's repository paths relative to the script location so it can run outside of $HOME/ariannamethod
- correct typographical issues in the README introduction

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'db'; ModuleNotFoundError: No module named 'bridge'; sqlite3.OperationalError: table field_cells has no column named context)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d82d6ea308329ad0d81c2dcb94110)