### PR TITLE
scribe: cap resonance_notes.content at 4 KB per row

### DIFF
--- a/device-1/scribe.py
+++ b/device-1/scribe.py
@@ -114,12 +114,24 @@ def init_db():
         conn.commit()
 
 
+MAX_CONTENT_BYTES = 4096  # cap per row; full responses go to file logs, not DB
+
+
+def _truncate(content: str) -> str:
+    if content is None:
+        return ""
+    if len(content) <= MAX_CONTENT_BYTES:
+        return content
+    return content[:MAX_CONTENT_BYTES] + "\n…[truncated]"
+
+
 def save_memory(content: str, context: str = "scribe_memory"):
     """Save content to resonance memory."""
     timestamp = datetime.now(timezone.utc).isoformat()
+    content = _truncate(content)
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        
+
         # Try to insert with 'source' column first
         try:
             c.execute("""
@@ -132,7 +144,7 @@ def save_memory(content: str, context: str = "scribe_memory"):
                 INSERT INTO resonance_notes (timestamp, content, context)
                 VALUES (?, ?, ?)
             """, (timestamp, content, context))
-        
+
         conn.commit()
 
 

--- a/device-1/voice_webhooks/scribe_webhook.py
+++ b/device-1/voice_webhooks/scribe_webhook.py
@@ -45,9 +45,23 @@ except ImportError:
 # Initialize Anthropic client
 client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
 
+MAX_CONTENT_BYTES = 4096  # cap per row; full responses go to file logs, not DB
+
+
+def _truncate(content):
+    if content is None:
+        return ""
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", errors="replace")
+    if len(content) <= MAX_CONTENT_BYTES:
+        return content
+    return content[:MAX_CONTENT_BYTES] + "\n…[truncated]"
+
+
 def log_to_resonance(source, content, context="scribe_conversation"):
     """Log message to resonance.sqlite3"""
     try:
+        content = _truncate(content)
         print(f"[DEBUG] Logging to resonance: DB={DB_PATH}, source={source}")
         conn = sqlite3.connect(str(DB_PATH), timeout=10)
         cursor = conn.cursor()


### PR DESCRIPTION
## Why
Cleanup 2026-05-07 (see \`memory/milestone_resonance_cleanup_2026_05_07.md\`) found \`resonance.sqlite3\` had grown to **2.4 GB**. Root cause for the scribe slice: both INSERT sites accepted \`content\` of arbitrary length. During the API-leak window (2025-11) full Anthropic API responses got persisted intact — 7,639 rows / 1,076 MB / 141 KB average / max 385 KB. Cleanup reclaimed 2.345 GB and the file is now 55 MB.

## Change
Add \`MAX_CONTENT_BYTES = 4096\` and a \`_truncate()\` helper at both writers; append \`…[truncated]\` so callers still see the cut.

- \`device-1/scribe.py:117\` — \`save_memory()\`
- \`device-1/voice_webhooks/scribe_webhook.py:48\` — \`log_to_resonance()\`

## Why 4 KB
Resonance DB is for short, queryable notes — not log archive. Full payloads belong in file logs (\`~/.arianna_api_guard.jsonl\`, run logs, etc.). 4 KB keeps headlines + a paragraph or two of context, fits cleanly in a single SQLite page, and means a single misbehaving caller cannot torch the DB again.

## Test plan
- [x] Local diff stages cleanly (\`git diff --staged --stat\`: 2 files, +28 / -2)
- [ ] After merge: invoke \`save_memory(\"x\" * 10000)\` and confirm row content length ≤ 4109 (4096 + truncated marker)
- [ ] Resonance DB size growth bounded going forward (sanity check after a week)

## Related
- \`memory/milestone_resonance_cleanup_2026_05_07.md\` — cleanup record
- \`memory/todo_scribe_content_cap.md\` — the TODO this closes
- \`memory/feedback_api_leak_safety.md\` — original leak context

— Defender (phone-1)